### PR TITLE
fix: improve screen reader experience by clarifying button meanings and hiding repetitive user profile info

### DIFF
--- a/apps/expo/src/components/composer.tsx
+++ b/apps/expo/src/components/composer.tsx
@@ -298,12 +298,16 @@ export const Composer = forwardRef<ComposerRef>((_, ref) => {
           )}
         >
           <TouchableOpacity
+            accessibilityLabel="Add image"
+            accessibilityRole="button"
             className="rounded border border-neutral-100 bg-neutral-50 p-1"
             onPress={() => Alert.alert("not yet implemented")}
           >
             <ImagePlus size={24} color="#888888" />
           </TouchableOpacity>
           <TouchableOpacity
+            accessibilityLabel="Use camera"
+            accessibilityRole="button"
             className="ml-2 rounded border border-neutral-100 bg-neutral-50 p-1"
             onPress={() => Alert.alert("not yet implemented")}
           >

--- a/apps/expo/src/components/feed-post.tsx
+++ b/apps/expo/src/components/feed-post.tsx
@@ -75,7 +75,7 @@ export const FeedPost = ({
       <View className="flex-1 flex-row">
         {/* left col */}
         <View className="flex flex-col items-center px-2">
-          <Link href={profileHref} asChild>
+          <Link href={profileHref} asChild accessibilityElementsHidden={true} importantForAccessibility="no-hide-descendants">
             <Pressable>
               {item.post.author.avatar ? (
                 <Image
@@ -155,6 +155,8 @@ export const FeedPost = ({
           {/* actions */}
           <View className="mt-2 flex-row justify-between pr-6">
             <TouchableOpacity
+              accessibilityLabel="Reply"
+              accessibilityRole="button"
               onPress={() =>
                 composer.open({
                   parent: item.post,
@@ -168,6 +170,8 @@ export const FeedPost = ({
               <Text>{item.post.replyCount}</Text>
             </TouchableOpacity>
             <TouchableOpacity
+              accessibilityLabel="Repost"
+              accessibilityRole="button"
               disabled={toggleRepost.isLoading}
               onPress={handleRepost}
               hitSlop={{ top: 0, bottom: 20, left: 10, right: 20 }}
@@ -183,6 +187,8 @@ export const FeedPost = ({
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
+              accessibilityLabel="Like"
+              accessibilityRole="button"
               disabled={toggleLike.isLoading}
               onPress={() => toggleLike.mutate()}
               hitSlop={{ top: 0, bottom: 20, left: 10, right: 20 }}
@@ -202,6 +208,8 @@ export const FeedPost = ({
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
+              accessibilityLabel="More options"
+              accessibilityRole="button"
               onPress={handleMore}
               hitSlop={{ top: 0, bottom: 20, left: 10, right: 20 }}
             >

--- a/apps/expo/src/components/profile-info.tsx
+++ b/apps/expo/src/components/profile-info.tsx
@@ -35,7 +35,7 @@ export const ProfileInfo = ({ profile, backButton }: Props) => {
       <Image
         source={{ uri: profile.banner }}
         className="h-32 w-full"
-        alt="banner image"
+        alt=""
       />
       {backButton && (
         <TouchableOpacity
@@ -51,7 +51,7 @@ export const ProfileInfo = ({ profile, backButton }: Props) => {
             <Image
               source={{ uri: profile.avatar }}
               className="h-20 w-20 rounded-full"
-              alt="avatar image"
+              alt=""
             />
           </View>
           {agent.session?.handle !== profile.handle && (

--- a/apps/expo/src/components/tabs.tsx
+++ b/apps/expo/src/components/tabs.tsx
@@ -36,6 +36,7 @@ interface TabProps {
 export const Tab = ({ active, onPress, text }: TabProps) => {
   return (
     <TouchableOpacity
+      accessibilityRole="button"
       onPress={onPress}
       className={cx(
         "ml-4 border-y-2 border-transparent py-3 text-xl",


### PR DESCRIPTION
Some improvements to navigating Graysky with a screen reader:

- Removed hard-coded `alt` from profile avatar and banner images (not specific enough to be useful, so more of a nuisance)
- Added "button" role to TouchableOpacity elements used as buttons (so that "button" is read aloud to screen reader users when on these buttons)
- Where missing, added accessibilityLabel (similar to `aria-label`) values to TouchableOpacity elements so that screen reader users can hear what the buttons do (e.g. "Reply," "Repost," "Like")
- Hid user avatar links from screen readers in post feed since the username is already linked and there's no need for folks to hear this info read to them twice in a row

I recommend testing with the screen reader VoiceOver on iOS or TalkBack on Android.

There should be zero visual regressions as a result of these changes. See [the React Native accessibility docs](https://reactnative.dev/docs/accessibility) for more info.