### PR TITLE
fix: added accessibilityHints, better labels and roles and accessible…

### DIFF
--- a/apps/expo/src/app/(tabs)/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/_layout.tsx
@@ -67,7 +67,9 @@ export default function AppLayout() {
         <Tabs.Screen
           name="notifications"
           options={{
-            title: "Notifications",
+            title: `Notifications${
+              notifications.data?.data?.count || undefined ? ", new items" : ""
+            }`,
             tabBarShowLabel: false,
             tabBarBadge: notifications.data?.data?.count || undefined,
             tabBarBadgeStyle: {

--- a/apps/expo/src/app/(tabs)/notifications.tsx
+++ b/apps/expo/src/app/(tabs)/notifications.tsx
@@ -265,7 +265,7 @@ const NotificationItem = ({
   );
   const wrapper = (children: React.ReactNode) =>
     href ? (
-      <Link href={href} asChild>
+      <Link href={href} asChild accessibilityHint="Opens post">
         <TouchableOpacity className={className}>{children}</TouchableOpacity>
       </Link>
     ) : (
@@ -285,31 +285,51 @@ const ProfileList = ({
   indexedAt,
 }: Pick<NotificationGroup, "actors" | "indexedAt"> & { action: string }) => {
   if (!actors[0]) return null;
+  const timeSinceNotif = timeSince(new Date(indexedAt));
   return (
     <View>
       <View className="flex-row">
-        {actors.map((actor) => (
-          <Link href={`/profile/${actor.handle}`} asChild key={actor.did}>
+        {actors.map((actor, index) => (
+          <Link
+            href={`/profile/${actor.handle}`}
+            asChild
+            key={actor.did}
+            accessibilityHint="Opens profile"
+          >
             <TouchableOpacity className="mr-2 rounded-full">
               <Image
                 className="h-8 w-8 rounded-full bg-neutral-200"
                 source={{ uri: actor.avatar }}
-                alt={actor.displayName}
+                alt={
+                  // TODO: find a better way to handle this
+                  action === "started following you"
+                    ? `${index === 0 ? "New follower: " : ""}${
+                        actor.displayName
+                      } @${actor.handle}`
+                    : ""
+                }
               />
             </TouchableOpacity>
           </Link>
         ))}
       </View>
-      <Text className="mt-2 text-base">
+      <View
+        className="mt-2 text-base"
+        style={{ flexDirection: "row", flexWrap: "wrap" }}
+      >
         <Text className="font-medium">
           {actors[0].displayName?.trim() ?? `@${actors[0].handle}`}
           {actors.length > 1 && ` and ${actors.length - 1} others`}
         </Text>
-        {" " + action}
-        <Text className="text-neutral-500">
-          {" · " + timeSince(new Date(indexedAt))}
+        <Text>{" " + action}</Text>
+        <Text
+          className="text-neutral-500"
+          accessibilityLabel={timeSinceNotif.accessible}
+        >
+          {" · "}
+          {timeSinceNotif.visible}
         </Text>
-      </Text>
+      </View>
     </View>
   );
 };

--- a/apps/expo/src/app/images/[post].tsx
+++ b/apps/expo/src/app/images/[post].tsx
@@ -63,6 +63,8 @@ export default function ImageModal() {
         }}
       />
       <TouchableOpacity
+        accessibilityLabel="Back"
+        accessibilityRole="button"
         onPress={() => router.back()}
         className="absolute right-5 z-10 h-10 w-10 items-center justify-center rounded-full bg-black/40"
         style={{ top: top + 10 }}

--- a/apps/expo/src/components/compose-button.tsx
+++ b/apps/expo/src/components/compose-button.tsx
@@ -7,6 +7,8 @@ export const ComposeButton = () => {
   const { open } = useComposer();
   return (
     <Pressable
+      accessibilityLabel="Compose post"
+      accessibilityRole="button"
       onPress={() => open()}
       className="absolute bottom-6 right-4 h-14 w-14 items-center justify-center rounded-full bg-neutral-800"
     >

--- a/apps/expo/src/components/composer.tsx
+++ b/apps/expo/src/components/composer.tsx
@@ -265,7 +265,11 @@ export const Composer = forwardRef<ComposerRef>((_, ref) => {
           )}
           <View className="flex-row px-2 pb-8 pt-2">
             <View className="shrink-0 px-2">
-              <View className="relative overflow-hidden rounded-full">
+              <View
+                className="relative overflow-hidden rounded-full"
+                accessibilityElementsHidden={true}
+                importantForAccessibility="no-hide-descendants"
+              >
                 <Avatar />
                 <Spinner show={send.isLoading} />
               </View>
@@ -318,6 +322,7 @@ export const Composer = forwardRef<ComposerRef>((_, ref) => {
             {rt.data?.graphemeLength} / {MAX_LENGTH}
           </Text>
           <TouchableOpacity
+            accessibilityRole="button"
             disabled={isEmpty || send.isLoading}
             className="ml-3 flex-row items-center rounded-full bg-neutral-800 px-3 py-2"
             onPress={() => send.mutate()}

--- a/apps/expo/src/components/embed.tsx
+++ b/apps/expo/src/components/embed.tsx
@@ -177,7 +177,7 @@ const ImageEmbed = ({
     case 1:
       const image = content.images[0]!;
       return (
-        <Link href={href} asChild>
+        <Link href={href} asChild accessibilityRole="image">
           <TouchableWithoutFeedback>
             <Image
               key={image.thumb}
@@ -198,7 +198,12 @@ const ImageEmbed = ({
       return (
         <View className="mt-1.5 flex flex-row justify-between overflow-hidden rounded">
           {content.images.map((image, i) => (
-            <Link href={`${href}?initial=${i}`} asChild key={image.fullsize}>
+            <Link
+              href={`${href}?initial=${i}`}
+              asChild
+              key={image.fullsize}
+              accessibilityRole="image"
+            >
               <TouchableWithoutFeedback className="w-[49%]">
                 <Image
                   key={image.thumb}
@@ -215,7 +220,12 @@ const ImageEmbed = ({
       return (
         <View className="mt-1.5 flex flex-row justify-between overflow-hidden rounded">
           {content.images.map((image, i) => (
-            <Link href={`${href}?initial=${i}`} asChild key={image.fullsize}>
+            <Link
+              href={`${href}?initial=${i}`}
+              asChild
+              key={image.fullsize}
+              accessibilityRole="image"
+            >
               <TouchableWithoutFeedback className="w-[32%]">
                 <Image
                   key={image.thumb}
@@ -276,7 +286,7 @@ export const PostEmbed = ({
   const postHref = `/${profileHref}/post/${uri.split("/").pop()}`;
 
   return (
-    <Link href={postHref} asChild>
+    <Link href={postHref} asChild accessibilityHint="Opens embedded post">
       <TouchableOpacity className="mt-1.5 flex-1 rounded border border-neutral-300 px-2 pb-2 pt-1">
         <View className="flex flex-row items-center overflow-hidden">
           <Image

--- a/apps/expo/src/components/post.tsx
+++ b/apps/expo/src/components/post.tsx
@@ -31,11 +31,14 @@ interface Props {
 export const Post = ({ post, hasParent, root }: Props) => {
   const { liked, likeCount, toggleLike } = useLike(post);
   const { reposted, repostCount, toggleRepost } = useRepost(post);
+  const replyCount = post.replyCount;
   const handleRepost = useHandleRepost(post, reposted, toggleRepost.mutate);
   const handleMore = usePostViewOptions(post);
   const composer = useComposer();
 
-  const profileHref = `/profile/${post.author.handle}`;
+  const postAuthorDisplayName = post.author.displayName;
+  const postAuthorHandle = post.author.handle;
+  const profileHref = `/profile/${postAuthorHandle}`;
 
   if (!AppBskyFeedPost.isRecord(post.record)) {
     return null;
@@ -50,37 +53,41 @@ export const Post = ({ post, hasParent, root }: Props) => {
         hasParent && "border-t",
       )}
     >
-      <Link href={profileHref} asChild>
-        <TouchableOpacity className="mb-2 flex-row">
-          {post.author.avatar ? (
-            <Image
-              source={{ uri: post.author.avatar }}
-              alt={post.author.handle}
-              className="h-12 w-12 rounded-full"
-            />
-          ) : (
-            <View className="h-12 w-12 items-center justify-center rounded-full bg-neutral-100">
-              <User size={32} color="#1C1C1E" />
-            </View>
-          )}
-          <View className="justify ml-3 flex-1 flex-row items-center">
-            <View className="flex-1">
+      <View className="mb-2 flex-row">
+        {post.author.avatar ? (
+          <Image
+            source={{ uri: post.author.avatar }}
+            alt=""
+            className="h-12 w-12 rounded-full"
+          />
+        ) : (
+          <View className="h-12 w-12 items-center justify-center rounded-full bg-neutral-100">
+            <User size={32} color="#1C1C1E" />
+          </View>
+        )}
+        <View className="justify ml-3 flex-1 flex-row items-center">
+          <Link href={profileHref} asChild accessibilityHint="Opens profile">
+            <TouchableOpacity className="flex-1">
               <Text
                 numberOfLines={1}
                 className="max-w-[85%] text-base font-semibold"
               >
-                {post.author.displayName}
+                {postAuthorDisplayName}
               </Text>
               <Text className="text-base leading-5 text-neutral-500">
-                @{post.author.handle}
+                @{postAuthorHandle}
               </Text>
-            </View>
-            <TouchableOpacity onPress={handleMore}>
-              <MoreVertical size={18} color="#1C1C1E" />
             </TouchableOpacity>
-          </View>
-        </TouchableOpacity>
-      </Link>
+          </Link>
+          <TouchableOpacity
+            accessibilityLabel="More options"
+            accessibilityRole="button"
+            onPress={handleMore}
+          >
+            <MoreVertical size={18} color="#1C1C1E" />
+          </TouchableOpacity>
+        </View>
+      </View>
       {/* text content */}
       {post.record.text && (
         <RichText
@@ -96,6 +103,10 @@ export const Post = ({ post, hasParent, root }: Props) => {
       {/* actions */}
       <View className="mt-4 flex-row items-center justify-between">
         <TouchableOpacity
+          accessibilityLabel={`Reply, ${replyCount} repl${
+            replyCount !== 1 ? "ies" : "y"
+          }`}
+          accessibilityRole="button"
           className="flex-row items-center gap-2 p-1"
           onPress={() =>
             composer.open({
@@ -105,9 +116,13 @@ export const Post = ({ post, hasParent, root }: Props) => {
           }
         >
           <MessageSquare size={18} color="#1C1C1E" />
-          <Text>{post.replyCount}</Text>
+          <Text>{replyCount}</Text>
         </TouchableOpacity>
         <TouchableOpacity
+          accessibilityLabel={`Repost, ${repostCount} repost${
+            repostCount !== 1 ? "s" : ""
+          }`}
+          accessibilityRole="button"
           className="flex-row items-center gap-2 p-1"
           disabled={toggleRepost.isLoading}
           onPress={handleRepost}
@@ -123,6 +138,10 @@ export const Post = ({ post, hasParent, root }: Props) => {
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
+          accessibilityLabel={`Like, ${likeCount} like${
+            likeCount !== 1 ? "s" : ""
+          }`}
+          accessibilityRole="button"
           className="flex-row items-center gap-2 p-1"
           disabled={toggleLike.isLoading}
           onPress={() => toggleLike.mutate()}

--- a/apps/expo/src/components/profile-info.tsx
+++ b/apps/expo/src/components/profile-info.tsx
@@ -39,6 +39,8 @@ export const ProfileInfo = ({ profile, backButton }: Props) => {
       />
       {backButton && (
         <TouchableOpacity
+          accessibilityLabel="Back"
+          accessibilityRole="button"
           onPress={() => router.back()}
           className="absolute left-4 top-4 items-center justify-center rounded-full bg-black/60 p-2"
         >

--- a/apps/expo/src/components/profile-view.tsx
+++ b/apps/expo/src/components/profile-view.tsx
@@ -289,6 +289,7 @@ export const ProfileView = ({
               ) : (
                 <FeedPost
                   {...item}
+                  // TODO: investigate & fix error with isReply logic below
                   isReply={mode === "replies" && data[index]?.hasReply}
                   inlineParent={mode !== "replies"}
                 />

--- a/apps/expo/src/components/tabs.tsx
+++ b/apps/expo/src/components/tabs.tsx
@@ -36,7 +36,7 @@ interface TabProps {
 export const Tab = ({ active, onPress, text }: TabProps) => {
   return (
     <TouchableOpacity
-      accessibilityRole="button"
+      accessibilityRole="tab"
       onPress={onPress}
       className={cx(
         "ml-4 border-y-2 border-transparent py-3 text-xl",

--- a/apps/expo/src/lib/utils/time.ts
+++ b/apps/expo/src/lib/utils/time.ts
@@ -5,23 +5,47 @@ export const timeSince = (date: Date) => {
   let interval = seconds / 31536000;
 
   if (interval > 1) {
-    return Math.floor(interval) + "y";
+    const years = Math.floor(interval);
+    return {
+      visible: years + "y",
+      accessible: `${years} year${years !== 1 ? "s" : ""} ago`,
+    };
   }
   interval = seconds / 2592000;
   if (interval > 1) {
-    return Math.floor(interval) + "mo";
+    const months = Math.floor(interval);
+    return {
+      visible: months + "mo",
+      accessible: `${months} month${months !== 1 ? "s" : ""} ago`,
+    };
   }
   interval = seconds / 86400;
   if (interval > 1) {
-    return Math.floor(interval) + "d";
+    const days = Math.floor(interval);
+    return {
+      visible: days + "d",
+      accessible: `${days} day${days !== 1 ? "s" : ""} ago`,
+    };
   }
   interval = seconds / 3600;
   if (interval > 1) {
-    return Math.floor(interval) + "h";
+    const hours = Math.floor(interval);
+    return {
+      visible: hours + "h",
+      accessible: `${hours} hour${hours !== 1 ? "s" : ""} ago`,
+    };
   }
   interval = seconds / 60;
   if (interval > 1) {
-    return Math.floor(interval) + "m";
+    const minutes = Math.floor(interval);
+    return {
+      visible: minutes + "m",
+      accessible: `${minutes} minute${minutes !== 1 ? "s" : ""} ago`,
+    };
   }
-  return Math.floor(seconds) + "s";
+  const secondsAgo = Math.floor(seconds);
+  return {
+    visible: secondsAgo + "s",
+    accessible: `${secondsAgo} second${seconds !== 1 ? "s" : ""} ago`,
+  };
 };


### PR DESCRIPTION
fix: added accessibilityHints, better labels and roles and accessible versions of timeSince text, among other a11y structure tweaks

- Notification tab now signals to screen reader users when there are new notifications, using the same approach as Twitter
- Slight improvements to notifications logic to make it more clear to screen readers what happened and when
- accessibilityHints added throughout the code to provide context for the various links screen reader users will encounter (e.g. some open profile pages, some open post details, etc.)
- New `timeSince` logic that provides an `accessible` and `visible` version of each label so that sighted users' experience is unchanged while screen reader users now hear useful info like "3 minutes ago" instead of "3 meters" 🙃 
- Corrected hiding of avatars from screen readers and removal of unhelpful alt text when appropriate
- Set image links to accessibilityRole="image" to avoid user confusion (not as much reason for blind and low-vision screen reader users to open these, and they are not very user-friendly modals for screen readers)
- Updated like, reply and repost buttons on posts to tell screen reader users both the action and the number of folks who have taken that action already e.g. "Reply, 10 replies: button"
- Refactoring and making code more DRY where possible as I carried out the above improvements

I noticed some TODOs that I deemed outside the scope of this PR, so I will mention them in Discord and/or GitHub issue or whatever other avenue we decide upon.