### PR TITLE
Remove second URL from share sheet

### DIFF
--- a/apps/expo/src/lib/hooks.ts
+++ b/apps/expo/src/lib/hooks.ts
@@ -187,10 +187,7 @@ export const usePostViewOptions = (post: AppBskyFeedDefs.PostView) => {
             await Share.share({
               message: `https://psky.app/profile/${
                 post.author.handle
-              }/post/${post.uri.split("/").pop()}`,
-              url: `https://psky.app/profile/${
-                post.author.handle
-              }/post/${post.uri.split("/").pop()}`,
+              }/post/${post.uri.split("/").pop()}`
             });
             break;
           case `Mute @${post.author.handle}`:


### PR DESCRIPTION
I noticed that Graysky copies the url of a post twice in the share sheet:

![IMG_4522](https://user-images.githubusercontent.com/14811170/235747856-d6a83d4b-1fdc-4e51-8fc6-7facdff7a313.png)
![IMG_4523](https://user-images.githubusercontent.com/14811170/235747864-f400d3b6-4bef-4d58-9651-dfd3c5cf75e4.png)

I think you can just remove the `url` property if the message is just the URL.