### PR TITLE
fix: restore feed post profile link with correct accessibilityLabel

### DIFF
--- a/apps/expo/src/components/feed-post.tsx
+++ b/apps/expo/src/components/feed-post.tsx
@@ -130,13 +130,13 @@ export const FeedPost = ({
               href={profileHref}
               accessibilityLabel={
                 isReply
-                  ? `Reply by ${postAuthorDisplayName} @${postAuthorHandle}`
-                  : `${postAuthorDisplayName} @${postAuthorHandle}`
+                  ? `Reply by ${postAuthorDisplayName} @${postAuthorHandle} ${timeSincePost.accessible}`
+                  : `${postAuthorDisplayName} @${postAuthorHandle} ${timeSincePost.accessible}`
               }
               accessibilityHint="Opens profile"
               asChild
             >
-              <View className="flex-row flex-wrap">
+              <TouchableWithoutFeedback className="flex-row flex-wrap">
                 <Text numberOfLines={1} className="max-w-[85%] text-base">
                   <Text className="font-semibold dark:text-neutral-50">
                     {postAuthorDisplayName}
@@ -146,14 +146,11 @@ export const FeedPost = ({
                   </Text>
                 </Text>
                 {/* get age of post - e.g. 5m */}
-                <Text
-                  className="text-base text-neutral-500 dark:text-neutral-400"
-                  accessibilityLabel={timeSincePost.accessible}
-                >
+                <Text className="text-base text-neutral-500 dark:text-neutral-400">
                   {" · "}
                   {timeSincePost.visible}
                 </Text>
-              </View>
+              </TouchableWithoutFeedback>
             </Link>
           </View>
           {/* inline "replying to so-and-so" */}


### PR DESCRIPTION
I think I accidentally converted the `TouchableWithoutFeedback` in feed post profile links to a `View` at some point during the merge conflict resolution for #13. This PR restores the link functionality and also improves the accessibilityLabel by having it read the timing of the post along with the poster's name and handle.

Testing steps: Ensure the username/handle/timestamp of feed posts functions as a link to the poster's profile page.