### PR TITLE
Test support for expo push notifications

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -39,7 +39,7 @@
     "expo-linking": "~5.0.2",
     "expo-localization": "~14.3.0",
     "expo-media-library": "^15.4.1",
-    "expo-notifications": "^0.23.0",
+    "expo-notifications": "^0.20.1",
     "expo-router": "2.0.5",
     "expo-sharing": "^11.5.0",
     "expo-splash-screen": "~0.20.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: ^15.4.1
         version: 15.4.1(expo@49.0.16)
       expo-notifications:
-        specifier: ^0.23.0
-        version: 0.23.0(expo@49.0.16)
+        specifier: ^0.20.1
+        version: 0.20.1(expo@49.0.16)
       expo-router:
         specifier: 2.0.5
         version: 2.0.5(expo-constants@14.4.2)(expo-linking@5.0.2)(expo-modules-autolinking@1.5.1)(expo-status-bar@1.6.0)(expo@49.0.16)(metro@0.80.0)(react-dom@18.2.0)(react-native-gesture-handler@2.12.1)(react-native-reanimated@3.3.0)(react-native-safe-area-context@4.6.3)(react-native-screens@3.26.0)(react-native@0.72.6)(react@18.2.0)
@@ -2388,35 +2388,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@expo/config-plugins@7.5.0:
-    resolution: {integrity: sha512-qOKjmgbddLh1vj9ytUT6AduhEans2cHgS42nopVgh5Wz8X+QUvPcCr1Yc8MvLM3OlbswBMCJceeosZa463i0uA==}
-    dependencies:
-      '@expo/config-types': 50.0.0-alpha.2
-      '@expo/fingerprint': 0.2.0
-      '@expo/json-file': 8.2.37
-      '@expo/plist': 0.0.20
-      '@expo/sdk-runtime-versions': 1.0.0
-      '@react-native/normalize-color': 2.1.0
-      chalk: 4.1.2
-      debug: 4.3.4
-      find-up: 5.0.0
-      getenv: 1.0.0
-      glob: 7.1.6
-      resolve-from: 5.0.0
-      semver: 7.5.4
-      slash: 3.0.0
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@expo/config-types@49.0.0:
     resolution: {integrity: sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA==}
-
-  /@expo/config-types@50.0.0-alpha.2:
-    resolution: {integrity: sha512-eAUMUg4wnw0bYovs+isibq4l9ssMacS/r0NolDxDdIX/N+ZjIEZ5DEl5GO8dnD0dKbN/DPWwUln7SG/nSYHfmw==}
-    dev: false
 
   /@expo/config@8.1.1:
     resolution: {integrity: sha512-IKC1aUXZ5ec4hPYkYkPFapwK8Z4oHWGgCtbtNc7WeeazxOI5+3gMEAbclcVweozqMtg057w5Cy1+8lYq5d4cSA==}
@@ -2442,24 +2415,6 @@ packages:
       '@babel/code-frame': 7.10.4
       '@expo/config-plugins': 7.2.5
       '@expo/config-types': 49.0.0
-      '@expo/json-file': 8.2.37
-      getenv: 1.0.0
-      glob: 7.1.6
-      require-from-string: 2.0.2
-      resolve-from: 5.0.0
-      semver: 7.5.3
-      slugify: 1.6.6
-      sucrase: 3.34.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@expo/config@8.3.1:
-    resolution: {integrity: sha512-5fNGAw5h/MDOc8Ulv9nonafPtOT042B7dF6vrVxSP3CY5qiVu0tCsmbL412wEcrAZ8MY7UMv9e6IzpGTgleYgg==}
-    dependencies:
-      '@babel/code-frame': 7.10.4
-      '@expo/config-plugins': 7.5.0
-      '@expo/config-types': 50.0.0-alpha.2
       '@expo/json-file': 8.2.37
       getenv: 1.0.0
       glob: 7.1.6
@@ -2523,21 +2478,6 @@ packages:
       dotenv: 16.0.3
       dotenv-expand: 10.0.0
       getenv: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@expo/fingerprint@0.2.0:
-    resolution: {integrity: sha512-k6MhJTrX4CYEwsyGemiLT8rnBwjRBYe0eKYAM3kqw0WbSHzkOJm739sgdswGLmA53iiX6FbB1TsiLnqt+h2U2w==}
-    hasBin: true
-    dependencies:
-      '@expo/spawn-async': 1.7.2
-      chalk: 4.1.2
-      debug: 4.3.4
-      find-up: 5.0.0
-      minimatch: 3.1.2
-      p-limit: 3.1.0
-      resolve-from: 5.0.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4564,7 +4504,7 @@ packages:
   /assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       is-nan: 1.3.2
       object-is: 1.1.5
       object.assign: 4.1.4
@@ -6418,14 +6358,6 @@ packages:
       expo: 49.0.16(@babel/core@7.23.2)
     dev: false
 
-  /expo-application@5.4.0(expo@49.0.16):
-    resolution: {integrity: sha512-7V6w/Fvg/Py10q/WHOjby0lOfcZAowNyVo4+DjkPsbu3ZtaLRkD8ZveXbImH9pRl75JN3nkkwhSSWZKDoMycjA==}
-    peerDependencies:
-      expo: '*'
-    dependencies:
-      expo: 49.0.16(@babel/core@7.23.2)
-    dev: false
-
   /expo-asset@8.10.1(expo@49.0.16):
     resolution: {integrity: sha512-5VMTESxgY9GBsspO/esY25SKEa7RyascVkLe/OcL1WgblNFm7xCCEEUIW8VWS1nHJQGYxpMZPr3bEfjMpdWdyA==}
     dependencies:
@@ -6481,18 +6413,6 @@ packages:
       expo: '*'
     dependencies:
       '@expo/config': 8.1.1
-      expo: 49.0.16(@babel/core@7.23.2)
-      uuid: 3.4.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /expo-constants@15.0.0(expo@49.0.16):
-    resolution: {integrity: sha512-HDg5irjqv3GWDmVtaVV+tjhEKgYuiN8V2tb6l1R22SfVvka3rb1qMA+/mqO5unaBOVaWZ3kRCrA5qn9buUoeJw==}
-    peerDependencies:
-      expo: '*'
-    dependencies:
-      '@expo/config': 8.3.1
       expo: 49.0.16(@babel/core@7.23.2)
       uuid: 3.4.0
     transitivePeerDependencies:
@@ -6713,8 +6633,8 @@ packages:
       invariant: 2.2.4
     dev: false
 
-  /expo-notifications@0.23.0(expo@49.0.16):
-    resolution: {integrity: sha512-57EBi56ipjkVKkG31+Y/GvAvK+IlFq3xZA2U4p50++LJhJmeDrwptrWFdwlJpYHGNVPgYLOVsFJmZelnh3+QFg==}
+  /expo-notifications@0.20.1(expo@49.0.16):
+    resolution: {integrity: sha512-Y4Y8IWYj/cSWCP/P167z3GRg//5ZlsznfMXi4ABdWOOpF0RGNpd5N17TxioNivtt7tMhZ/o1vmzFxulhy0nBWg==}
     peerDependencies:
       expo: '*'
     dependencies:
@@ -6724,8 +6644,8 @@ packages:
       assert: 2.1.0
       badgin: 1.2.3
       expo: 49.0.16(@babel/core@7.23.2)
-      expo-application: 5.4.0(expo@49.0.16)
-      expo-constants: 15.0.0(expo@49.0.16)
+      expo-application: 5.3.1(expo@49.0.16)
+      expo-constants: 14.4.2(expo@49.0.16)
       fs-extra: 9.1.0
       uuid: 3.4.0
     transitivePeerDependencies:
@@ -7746,7 +7666,7 @@ packages:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-tostringtag: 1.0.0
     dev: false
 
@@ -7914,8 +7834,8 @@ packages:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
+      call-bind: 1.0.5
+      define-properties: 1.2.1
     dev: false
 
   /is-negative-zero@2.0.2:
@@ -10213,8 +10133,8 @@ packages:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
+      call-bind: 1.0.5
+      define-properties: 1.2.1
     dev: false
 
   /object-keys@1.1.1:
@@ -13226,7 +13146,7 @@ packages:
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
       is-typed-array: 1.1.12
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.13
     dev: false
 
   /utils-merge@1.0.1:


### PR DESCRIPTION
This is a working example of expo push notifications implementation.

You can build it and test it with https://expo.dev/notifications.

Please note that it doesn't work in simulators, and that you must get credentials for APNs and FCM (and rebuild the app) to get it working on a development client (see https://docs.expo.dev/push-notifications/push-notifications-setup/#get-credentials-for-development-builds for how to get those credentials).

Please also note that blsky.app/blsky.social most probably directly talk to APNs and FCM, so modifications are needed to (1) get a DevicePushToken rather than a ExpoPushToken, and to (2) send the token to the blsky.app/blsky.social servers (see https://github.com/bluesky-social/social-app/blob/047f74c67de72c74ae5973612b566b2330dcd4a4/src/lib/notifications/notifications.ts#L26)