### PR TITLE
Refactor ChangePasswordFlow to use Stage enum for clarity

### DIFF
--- a/apps/expo/src/components/change-password-flow.tsx
+++ b/apps/expo/src/components/change-password-flow.tsx
@@ -81,7 +81,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
   });
 
   switch (stage) {
-    case 1:
+    case Stage.EnterEmail:
       return (
         <KeyboardAwareScrollView className="flex-1 px-4">
           <View className="my-4 flex-1">
@@ -118,7 +118,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
           </View>
         </KeyboardAwareScrollView>
       );
-    case 2:
+    case Stage.EnterResetCode:
       return (
         <KeyboardAwareScrollView className="flex-1 px-4">
           <View className="my-4 flex-1">
@@ -207,7 +207,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
           </View>
         </KeyboardAwareScrollView>
       );
-    case 3:
+    case Stage.Success:
       return (
         <Animated.View
           entering={FadeIn}

--- a/apps/expo/src/components/change-password-flow.tsx
+++ b/apps/expo/src/components/change-password-flow.tsx
@@ -191,7 +191,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
             </View>
           </View>
           <View className="flex-row items-center justify-between pt-2">
-            <TextButton onPress={() => setStage(Stage.EnterResetCode)} title="Back" />
+            <TextButton onPress={() => setStage(Stage.EnterEmail)} title="Back" />
             {!changePassword.isLoading ? (
               <TextButton
                 disabled={

--- a/apps/expo/src/components/change-password-flow.tsx
+++ b/apps/expo/src/components/change-password-flow.tsx
@@ -23,11 +23,17 @@ interface Props {
   defaultEmail?: string;
 }
 
+enum Stage {
+  EnterEmail,
+  EnterResetCode,
+  Success,
+}
+
 export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
   const theme = useTheme();
   const agent = useAgent();
 
-  const [stage, setStage] = useState<1 | 2 | 3>(1);
+  const [stage, setStage] = useState<Stage>(Stage.EnterEmail);
   const [email, setEmail] = useState<string>(defaultEmail);
   const [token, setToken] = useState<string>("");
   const [newPassword, setNewPassword] = useState<string>("");
@@ -40,7 +46,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
         email,
       });
     },
-    onSettled: () => setStage(2),
+    onSettled: () => setStage(Stage.EnterResetCode),
   });
 
   const changePassword = useMutation({
@@ -54,7 +60,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
         token: token.trim(),
       });
     },
-    onSuccess: () => setStage(3),
+    onSuccess: () => setStage(Stage.Success),
     onError: (err) => {
       if (err instanceof PasswordError) {
         showToastable({
@@ -185,7 +191,7 @@ export const ChangePasswordFlow = ({ defaultEmail = "" }: Props) => {
             </View>
           </View>
           <View className="flex-row items-center justify-between pt-2">
-            <TextButton onPress={() => setStage(1)} title="Back" />
+            <TextButton onPress={() => setStage(Stage.EnterResetCode)} title="Back" />
             {!changePassword.isLoading ? (
               <TextButton
                 disabled={


### PR DESCRIPTION
The primary goal of this change is to improve code readability and maintainability.

Key Changes:

Introduced an enum Stage to replace numeric values (1, 2, 3) for representing different stages in the password change process.
Updated the useState hook to initialize the stage using the Stage enum.
Modified the switch-case logic in the component to use the Stage enum, enhancing the clarity of each case.
