### PR TITLE
patch expo-image-picker to support "browse" on android

### DIFF
--- a/apps/expo/src/lib/composer/utils.tsx
+++ b/apps/expo/src/lib/composer/utils.tsx
@@ -419,7 +419,7 @@ export const useImages = (anchorRef?: React.RefObject<TouchableHighlight>) => {
                   router.setParams({ ...searchParams, gif: "" });
                   setImages((prev) => [
                     ...prev,
-                    ...result.assets.map((a) => ({ asset: a, alt: "" })),
+                    ...result.assets.slice(0, 4).map((a) => ({ asset: a, alt: "" })),
                   ]);
                 }
               });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "pnpm": {
     "patchedDependencies": {
       "nativewind@2.0.11": "patches/nativewind@2.0.11.patch",
-      "react-native-svg@14.1.0": "patches/react-native-svg@14.1.0.patch"
+      "react-native-svg@14.1.0": "patches/react-native-svg@14.1.0.patch",
+      "expo-image-picker@14.5.0": "patches/expo-image-picker@14.5.0.patch"
     },
     "overrides": {
       "use-deep-compare": "npm:use-deep-compare-dequal-update@2.0.0",

--- a/patches/expo-image-picker@14.5.0.patch
+++ b/patches/expo-image-picker@14.5.0.patch
@@ -1,0 +1,89 @@
+diff --git a/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt b/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+index 6c4255640db70623510e9cc26aa3f542b13ed258..0281f1d2ae0b23413efef8ac7ac215ffb4f3973d 100644
+--- a/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
++++ b/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+@@ -14,6 +14,7 @@ import expo.modules.imagepicker.UNLIMITED_SELECTION
+ import expo.modules.imagepicker.getAllDataUris
+ import expo.modules.imagepicker.toMediaType
+ import expo.modules.kotlin.activityresult.AppContextActivityResultContract
++import expo.modules.kotlin.exception.Exceptions
+ import expo.modules.kotlin.providers.AppContextProvider
+ import java.io.Serializable
+ 
+@@ -28,49 +29,23 @@ internal class ImageLibraryContract(
+   private val appContextProvider: AppContextProvider,
+ ) : AppContextActivityResultContract<ImageLibraryContractOptions, ImagePickerContractResult> {
+   private val contentResolver: ContentResolver
+-    get() = requireNotNull(appContextProvider.appContext.reactContext) {
+-      "React Application Context is null"
+-    }.contentResolver
++    get() = appContextProvider.appContext.reactContext?.contentResolver
++      ?: throw Exceptions.ReactContextLost()
+ 
+   override fun createIntent(context: Context, input: ImageLibraryContractOptions): Intent {
+-    val request = PickVisualMediaRequest.Builder()
+-      .setMediaType(
+-        when (input.options.mediaTypes) {
+-          MediaTypes.VIDEOS -> {
+-            PickVisualMedia.VideoOnly
+-          }
+-
+-          MediaTypes.IMAGES -> {
+-            PickVisualMedia.ImageOnly
+-          }
+-
+-          else -> {
+-            PickVisualMedia.ImageAndVideo
+-          }
+-        }
+-      )
+-      .build()
++    val intent = Intent(Intent.ACTION_GET_CONTENT)
++            .addCategory(Intent.CATEGORY_OPENABLE)
++            .setType("image/*")
+ 
+     if (input.options.allowsMultipleSelection) {
+-      val selectionLimit = input.options.selectionLimit
+-
+-      if (selectionLimit == 1) {
+-        // If multiple selection is allowed but the limit is 1, we should ignore
+-        // the multiple selection flag and just treat it as a single selection.
+-        return PickVisualMedia().createIntent(context, request)
++      if(input.options.selectionLimit == 1) {
++        return intent
+       }
+ 
+-      if (selectionLimit > 1) {
+-        return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
+-      }
+-
+-      // If the selection limit is 0, it is the same as unlimited selection.
+-      if (selectionLimit == UNLIMITED_SELECTION) {
+-        return PickMultipleVisualMedia().createIntent(context, request)
+-      }
++      intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+     }
+ 
+-    return PickVisualMedia().createIntent(context, request)
++    return intent
+   }
+ 
+   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
+@@ -86,9 +61,9 @@ internal class ImageLibraryContract(
+           )
+         } else {
+           if (intent.data != null) {
+-            intent.data?.let {
+-              val type = it.toMediaType(contentResolver)
+-              ImagePickerContractResult.Success(listOf(type to it))
++            intent.data?.let { uri ->
++              val type = uri.toMediaType(contentResolver)
++              ImagePickerContractResult.Success(listOf(type to uri))
+             }
+           } else {
+             uris.firstOrNull()?.let { uri ->
+@@ -104,3 +79,4 @@ internal class ImageLibraryContract(
+ internal data class ImageLibraryContractOptions(
+   val options: ImagePickerOptions
+ ) : Serializable
++

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   sharp: 0.32.6
 
 patchedDependencies:
+  expo-image-picker@14.5.0:
+    hash: viwdpenalsrxy5nuzgowpopdam
+    path: patches/expo-image-picker@14.5.0.patch
   nativewind@2.0.11:
     hash: 4qfpcgvukjl323s5mtctmu3ynu
     path: patches/nativewind@2.0.11.patch
@@ -142,7 +145,7 @@ importers:
         version: 11.5.0(expo@49.0.21)
       expo-image-picker:
         specifier: ~14.5.0
-        version: 14.5.0(expo@49.0.21)
+        version: 14.5.0(patch_hash=viwdpenalsrxy5nuzgowpopdam)(expo@49.0.21)
       expo-insights:
         specifier: ~0.4.0
         version: 0.4.0(expo@49.0.21)
@@ -7950,7 +7953,7 @@ packages:
       expo-image-loader: 4.4.0(expo@49.0.21)
     dev: false
 
-  /expo-image-picker@14.5.0(expo@49.0.21):
+  /expo-image-picker@14.5.0(patch_hash=viwdpenalsrxy5nuzgowpopdam)(expo@49.0.21):
     resolution: {integrity: sha512-9icvfQuWMdNKufFqu+FxenKcfybz9ior+XYQCIl/q5+mpHPo2tKq8I30vu2BjsOJ0Cfo7V4vMeN7a9F/3ooUfQ==}
     peerDependencies:
       expo: '*'
@@ -7958,6 +7961,7 @@ packages:
       expo: 49.0.21(@babel/core@7.23.6)
       expo-image-loader: 4.4.0(expo@49.0.21)
     dev: false
+    patched: true
 
   /expo-image@1.10.1(expo@49.0.21):
     resolution: {integrity: sha512-NwJt2FS6sZXeP92RpsZxBKSnCPWMdcJ2Q2bXHc8WgOkLLInvRd0yBKAzEusXTZ6+N+RqAcWVojlh3EBbSQhkiA==}


### PR DESCRIPTION
See: https://github.com/bluesky-social/social-app/pull/2384

I can't guarantee some of the options that you have in there will continue to work, but they *should*. The only one that doesn't work is limiting the number of selections. I added a quick fix to make sure it is limited to four though.

I also didn't bother making this work to select videos but I don't think that should be an issue for you? In bsky, I added a little toast whenever a user tries to select more than four. Takes the first four and let's them know the max is four 🤷‍♀️ 

Also, test before using 🙏 works fine in bsky so should here too.