### PR TITLE
feat: Add 2factor Login Support

### DIFF
--- a/apps/expo/src/app/(auth)/sign-in.tsx
+++ b/apps/expo/src/app/(auth)/sign-in.tsx
@@ -17,7 +17,7 @@ import { msg, Trans } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
 import { useTheme } from "@react-navigation/native";
 import { useMutation } from "@tanstack/react-query";
-import { LockIcon, ShieldAlertIcon, UserIcon } from "lucide-react-native";
+import { LockIcon, ShieldAlertIcon, UserIcon, RectangleEllipsis } from "lucide-react-native";
 import { z } from "zod";
 
 import { Button } from "~/components/button";
@@ -27,6 +27,8 @@ import { TextInput } from "~/components/themed/text-input";
 import { TransparentHeaderUntilScrolled } from "~/components/transparent-header";
 import { useAuth } from "~/lib/agent";
 import { useLinkPress } from "~/lib/hooks/link-press";
+import { is2FactorError } from "~/lib/utils/login";
+
 
 export default function SignIn() {
   const { login: authLogin } = useAuth();
@@ -39,6 +41,8 @@ export default function SignIn() {
 
   const [identifier, setIdentifier] = useState(handle ?? "");
   const [password, setPassword] = useState("");
+  const [requiredTwoFactor, setRequiredTwoFactor] = useState(false);
+  const [twoFactor, setTwoFactor] = useState<string>("");
   const [hasFocusedPassword, setHasFocusedPassword] = useState(false);
 
   const login = useMutation({
@@ -47,7 +51,7 @@ export default function SignIn() {
       const normalizedIdentifier = identifier.startsWith("@")
         ? identifier.slice(1).trim()
         : identifier.trim();
-      await authLogin(normalizedIdentifier, password);
+      await authLogin(normalizedIdentifier, password, twoFactor !== '' ? twoFactor : undefined);
     },
     onSuccess: () => {
       // Dismiss the auth modal and navigate to feeds
@@ -56,12 +60,17 @@ export default function SignIn() {
       }
       router.replace("/(feeds)/feeds");
     },
-    onError: (err) =>
+    onError: (err) => {
+      if (is2FactorError(err)) {
+        setRequiredTwoFactor(true);
+        return;
+      }
       showToastable({
         title: _(msg`Could not log you in`),
         message: err instanceof Error ? err.message : _(msg`Unknown error`),
         status: "warning",
-      }),
+      })
+    },
   });
 
   return (
@@ -163,6 +172,20 @@ export default function SignIn() {
               </View>
             </Animated.View>
           )}
+
+          {requiredTwoFactor && (<View
+            className="mb-1 flex-row items-center rounded-b-sm rounded-t-lg pl-3"
+            style={{ backgroundColor: theme.colors.card }}
+          >
+            <RectangleEllipsis size={18} color="rgb(163 163 163)" />
+            <TextInput
+              className="flex-1 flex-row items-center px-2 py-3 text-base leading-5"
+              placeholder={_(msg`2Factor Code`)}
+              value={twoFactor}
+              onChangeText={setTwoFactor}
+              autoCapitalize="none"
+            />
+          </View>)}
         </KeyboardAwareScrollView>
       </TransparentHeaderUntilScrolled>
       <KeyboardStickyView

--- a/apps/expo/src/lib/utils/login.ts
+++ b/apps/expo/src/lib/utils/login.ts
@@ -1,0 +1,7 @@
+
+/* matches: 'A sign in code has been sent to your email address' */
+const TwoFactorRegex = /sign in code.*sent/i
+
+export function is2FactorError(error: Error): boolean {
+  return TwoFactorRegex.test(error?.message)
+}


### PR DESCRIPTION
## Overview
Currently, Graysky doesn't support two factor codes. You are only notified that is needed by the SDK throwing an exception. This code adds an error checker that sees if the 2FA message exists in the exception.

If there is no desire to support this, could https://github.com/mozzius/graysky/issues/542 be considered, it would push this issue into the PDS layer. 

### Current Login
**Note, the screen recorder automatically blurs the password field in IOS**

https://github.com/user-attachments/assets/2ecafd33-8344-460e-85fd-30bc88b82604

### PR Changes in Simulator

**Fair amount of waiting for 2FA code**


https://github.com/user-attachments/assets/2ac6b033-a0a7-4d53-9db4-e5a5837af4dc



